### PR TITLE
Setup registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: ruby
 services:
   - docker
 
+before_install:
+  - docker version
+
 install:
   - gem install rspec serverspec docker-api
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,6 @@ script:
 
 after_success:
   - docker build -f Dockerfile -t "$DOCKER_USERNAME"/alpine:3.6 --build-arg TAG=3.6 .
-
-before_deploy:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-
-deploy:
   - docker push "$DOCKER_USERNAME"/alpine:3.6
-
-after_deploy:
   - docker logout

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ services:
 
 before_install:
   - docker version
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - docker version
 
 install:
   - gem install rspec serverspec docker-api

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,15 @@ install:
 
 script:
   - rspec spec/Dockerfile_spec.rb
+
+after_success:
+  - docker build -f Dockerfile -t "$DOCKER_USERNAME"/alpine:3.6 --build-arg TAG=3.6 .
+
+before_deploy:
+  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
+deploy:
+  - docker push "$DOCKER_USERNAME"/alpine:3.6
+
+after_deploy:
+  - docker logout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,2 @@
-FROM alpine:3.4
+ARG TAG=latest
+FROM alpine:$TAG

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -3,7 +3,7 @@ require "docker"
 
 describe "Dockerfile" do
   before(:all) do
-    image = Docker::Image.build_from_dir('.', { 'dockerfile' => 'Dockerfile', 't' => 'cristobal23/alpine:3.4', 'buildargs' => '{ "TAG": "3.4" }' })
+    image = Docker::Image.build_from_dir('.', { 'dockerfile' => 'Dockerfile', 't' => 'cristobal23/alpine:3.6', 'buildargs' => '{ "TAG": "3.6" }' })
 
     set :os, family: :linux
     set :backend, :docker
@@ -11,7 +11,7 @@ describe "Dockerfile" do
   end
 
   it "installs the right version of Alpine" do
-    expect(os_version).to include("3.4.6")
+    expect(os_version).to include("3.6.2")
   end
 
   def os_version

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -3,7 +3,7 @@ require "docker"
 
 describe "Dockerfile" do
   before(:all) do
-    image = Docker::Image.build_from_dir('.', { 'dockerfile' => 'Dockerfile', 'repo_tag' => 'cristobal23/alpine:3.4' })
+    image = Docker::Image.build_from_dir('.', { 'dockerfile' => 'Dockerfile', 't' => 'cristobal23/alpine:3.4', 'buildargs' => '{ "TAG": "3.4" }' })
 
     set :os, family: :linux
     set :backend, :docker

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -3,7 +3,7 @@ require "docker"
 
 describe "Dockerfile" do
   before(:all) do
-    image = Docker::Image.build_from_dir('.')
+    image = Docker::Image.build_from_dir('.', { 'dockerfile' => 'Dockerfile' })
 
     set :os, family: :linux
     set :backend, :docker

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -3,7 +3,9 @@ require "docker"
 
 describe "Dockerfile" do
   before(:all) do
-    image = Docker::Image.build_from_dir('.', { 'dockerfile' => 'Dockerfile', 't' => 'cristobal23/alpine:3.6', 'buildargs' => '{ "TAG": "3.6" }' })
+    image = Docker::Image.build_from_dir('.', { 'dockerfile' => 'Dockerfile',
+                                                't' => 'cristobal23/alpine:3.6',
+                                                'buildargs' => '{ "TAG": "3.6" }' })
 
     set :os, family: :linux
     set :backend, :docker

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -3,7 +3,7 @@ require "docker"
 
 describe "Dockerfile" do
   before(:all) do
-    image = Docker::Image.build_from_dir('.', { 'dockerfile' => 'Dockerfile' })
+    image = Docker::Image.build_from_dir('.', { 'dockerfile' => 'Dockerfile', 'repo_tag' => 'cristobal23/alpine:3.4' })
 
     set :os, family: :linux
     set :backend, :docker


### PR DESCRIPTION
This PR sets up the test suite to build the `Dockerfile` using arguments to parameterize the base image tag.

As of Docker [v17.05](https://github.com/moby/moby/releases/tag/v17.05.0-ce) you can now have an `ARG` instruction precede the `FROM` instruction. Using `ARG` in `FROM` allows one to pass in a build-time argument to determine which base image is used for initializing the new build.  First, a failing test is added to expect an Alpine Linux version 3.6.2 when the build-time argument TAG=3.6 is passed.  Once it is verified that the test is failing, then the `Dockerfile` is modified just enough to get the test to pass.  During this process, it was discovered that the default version of Docker provided in TravisCI is v17.03 which did not yet have support for `ARG` in `FROM`.  After upgrading the version of Docker on the TravisCI environment, the test was able to pass. TravisCI was then configured to build the `Dockerfile` upon completion of successfully passing test suite.

Hence, when the following command is used:
```bash
docker build -f Dockerfile --build-arg TAG=3.6 .
```
A container is created from `alpine:3.6` base image.

With the new image successfully building, the remote DockerHub registry was configured to store the resulting images pushed by TravisCI.